### PR TITLE
Minor cleanup, and moved AlignmentRecord ahead of Fragment to clean up compile issue.

### DIFF
--- a/src/main/resources/avro/bdg.avdl
+++ b/src/main/resources/avro/bdg.avdl
@@ -57,53 +57,11 @@ record Contig {
   union { null, string } species = null;
 }
 
-record Sequence {
-  union { null, string } bases;
-  union { null, string } qualities;
-}
-
-/**
-   The DNA fragment that is was targeted by the sequencer, resulting in
-   one or more reads.
-*/
-record Fragment {
-  /**
-     The name of this Fragment.
-  */
-  union { null, string } readName = null;
-
-  union { null, string } instrument;
-	union { null, string } runId;
-  /**
-     The following are Illumina specific, is it a problem?
-   */
-  union { null, string } flowcellId;
-  union { null, int} lane = null;
-  union { null, int} tile = null;
-  union { null, int} surface = null;
-  union { null, int} xPosition = null;
-  union { null, int} yPosition = null;
-
-  /**
-    Fragment's insert size derived from alignment, if the reads have been
-    aligned.
-   */
-  union { null, int} fragmentSize = null;
-
-  /**
-   The sequences read from this fragment.
-   */
-  array<Sequence> sequences = [];
-  array<AlignmentRecord> alignments = [];
-}
-
-
 record AlignmentRecord {
-
-  
+ 
   /**
-    Read number within the array of fragment reads.
-  */
+   Read number within the array of fragment reads.
+   */
   union { int, null } readNum = 0;
 
   /**
@@ -297,6 +255,37 @@ record AlignmentRecord {
    mate is unaligned, or if the mate does not exist.
    */
   union { null, Contig } mateContig = null;
+}
+
+record Sequence {
+  union { null, string } bases = null;
+  union { null, string } qualities = null;
+}
+
+/**
+   The DNA fragment that is was targeted by the sequencer, resulting in
+   one or more reads.
+*/
+record Fragment {
+  /**
+   The name of this Fragment.
+   */
+  union { null, string } readName = null;
+
+  union { null, string } instrument = null;
+  union { null, string } runId = null; 
+
+  /**
+   Fragment's insert size derived from alignment, if the reads have been
+   aligned.
+   */
+  union { null, int } fragmentSize = null;
+
+  /**
+   The sequences read from this fragment.
+   */
+  array<Sequence> sequences = [];
+  array<AlignmentRecord> alignments = [];
 }
 
 /**


### PR DESCRIPTION
Hi @ilveroluca! Apologies for taking such a while to get to this. I had to reorder the code to clean up the compile issue, which unfortunately did a number on the diff. Essentially, since `Fragment` used `AlignmentRecord`, `AlignmentRecord` had to be ahead of `Fragment` in the avro description language. Anyways, the remaining cleanup that I did was to remove the Illumina specific fields. I think that there are a few comments that need to be addressed on the [original pull request](https://github.com/bigdatagenomics/bdg-formats/pull/44) (I think it's mostly documentation cleanup?), but otherwise I think we're very close to getting this merged.
